### PR TITLE
[FEAT]- 리뷰 가져오기 기능 구현 , DB review테이블에 userUID, kakaoUID추가

### DIFF
--- a/src/main/java/com/LeaveIt/server/controller/ReviewController.java
+++ b/src/main/java/com/LeaveIt/server/controller/ReviewController.java
@@ -1,0 +1,36 @@
+package com.LeaveIt.server.controller;
+
+
+import com.LeaveIt.server.controller.model.request.ReviewRequest;
+import com.LeaveIt.server.controller.model.response.ReviewResponse;
+import com.LeaveIt.server.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewController {
+
+
+    private  final ReviewService reviewService;
+
+
+    @GetMapping("/get/review/{id}")
+    public List<ReviewRequest> getFeed(
+            @PathVariable String id){
+
+        return  reviewService.findFeed(id);
+    }
+
+    @PostMapping("/save/review")
+    public ReviewResponse saveFeed(
+            @RequestBody ReviewResponse response){
+
+      return   reviewService.saveFeed(response);
+    }
+
+
+}

--- a/src/main/java/com/LeaveIt/server/controller/model/request/ReviewRequest.java
+++ b/src/main/java/com/LeaveIt/server/controller/model/request/ReviewRequest.java
@@ -1,0 +1,58 @@
+package com.LeaveIt.server.controller.model.request;
+
+
+import com.LeaveIt.server.controller.model.response.ReviewResponse;
+import com.LeaveIt.server.repository.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Data
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class ReviewRequest {
+    private String  feedUID;
+
+    private String nickname;
+
+    private  String content;
+
+    private String feedImage;
+
+    private  Integer likeCount;
+
+    private  Integer starCount;
+
+    private  String placeArea;
+
+    private Boolean isUserLiked;
+
+    private LocalDateTime createdAt;
+
+
+
+
+
+
+    public List<ReviewRequest> Review_To_DTO(List<Review> reviews) {
+        return reviews.stream()
+                .map(review -> ReviewRequest.builder()
+                        .feedUID(UUID.randomUUID().toString())
+                        .feedImage(review.getFeedImage())
+                        .content(review.getContent())
+                        .likeCount(review.getLikeCount())
+                        .starCount(review.getStarCount())
+                        .placeArea(review.getPlaceArea())
+                        .isUserLiked(review.getIsUserLiked())
+                        .createdAt(LocalDateTime.now())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/LeaveIt/server/controller/model/response/ReviewResponse.java
+++ b/src/main/java/com/LeaveIt/server/controller/model/response/ReviewResponse.java
@@ -1,0 +1,66 @@
+package com.LeaveIt.server.controller.model.response;
+
+import com.LeaveIt.server.repository.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Slf4j
+@Builder
+public class ReviewResponse {
+
+
+    private String  feedUID;
+
+    private  String kaKaoUID;
+
+    private  String userUID;
+
+    private String nickname;
+
+    private  String content;
+
+    private String feedImage;
+
+    private  Integer likeCount;
+
+    private  Integer starCount;
+
+    private  String placeArea;
+
+    private Boolean isUserLiked;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+
+
+
+    public Review DTO_To_Review(ReviewResponse response){
+
+
+        log.info(response.toString());
+        return Review.builder()
+                .feedUID(UUID.randomUUID().toString())
+                .userUID(response.getUserUID())
+                .kaKaoUID(response.getKaKaoUID())
+                .nickname(response.getNickname())
+                .content(response.getContent())
+                .feedImage(response.getFeedImage())
+                .likeCount(response.getLikeCount())
+                .starCount(response.getStarCount())
+                .placeArea(response.getPlaceArea())
+                .isUserLiked(response.getIsUserLiked())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/LeaveIt/server/repository/ReviewRepository.java
+++ b/src/main/java/com/LeaveIt/server/repository/ReviewRepository.java
@@ -1,0 +1,22 @@
+package com.LeaveIt.server.repository;
+
+import com.LeaveIt.server.controller.model.request.ReviewRequest;
+import com.LeaveIt.server.repository.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+
+@Repository
+public interface ReviewRepository  extends JpaRepository<Review , String> {
+
+
+    @Query(" select  r.content,r.feedImage,r.likeCount,r.placeArea,r.starCount,r.feedImage   from Review r where :kakaoUID=r.kaKaoUID")
+     Review findByUserKaKaoReview(@Param("kakaoUID") String kakaoUID);
+
+    @Query("select r from Review r where r.userUID = :userUID")
+    List<Review> findAllByUserReview(@Param("userUID") String userUID);
+}

--- a/src/main/java/com/LeaveIt/server/repository/entity/Review.java
+++ b/src/main/java/com/LeaveIt/server/repository/entity/Review.java
@@ -1,0 +1,58 @@
+package com.LeaveIt.server.repository.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.antlr.v4.runtime.misc.NotNull;
+
+import java.time.LocalDateTime;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Entity
+@Table(name = "review")
+public class Review {
+
+    @Id
+    @Column(name = "feeduid")
+    private String  feedUID;
+
+
+    @Column(name = "kakaouid")
+    private  String kaKaoUID;
+
+    @Column(name = "useruid")
+    private  String userUID;
+
+    private String nickname;
+
+    private  String content;
+
+    @Column(name = "feedimage")
+    private String feedImage;
+
+    @Column(name = "like_count")
+    private  Integer likeCount;
+
+    @Column(name = "star_count")
+    private  Integer starCount;
+
+    @Column(name = "place_area")
+    private  String placeArea;
+
+    @Column(name = "is_user_liked")
+    private Boolean isUserLiked;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/LeaveIt/server/service/ReviewService.java
+++ b/src/main/java/com/LeaveIt/server/service/ReviewService.java
@@ -1,0 +1,16 @@
+package com.LeaveIt.server.service;
+
+import com.LeaveIt.server.controller.model.request.ReviewRequest;
+import com.LeaveIt.server.controller.model.response.ReviewResponse;
+import com.LeaveIt.server.repository.entity.Review;
+
+import java.util.List;
+
+public interface ReviewService {
+
+    ReviewResponse saveFeed(ReviewResponse feedResponse);
+
+
+    List<ReviewRequest> findFeed(String id);
+
+}

--- a/src/main/java/com/LeaveIt/server/service/ReviewServiceImpl.java
+++ b/src/main/java/com/LeaveIt/server/service/ReviewServiceImpl.java
@@ -1,0 +1,35 @@
+package com.LeaveIt.server.service;
+
+
+import com.LeaveIt.server.controller.model.request.ReviewRequest;
+import com.LeaveIt.server.controller.model.response.ReviewResponse;
+import com.LeaveIt.server.repository.ReviewRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService {
+
+
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    @Transactional
+    public ReviewResponse saveFeed(ReviewResponse feedResponse) {
+
+        ReviewResponse response = new ReviewResponse();
+        reviewRepository.save(response.DTO_To_Review(feedResponse));
+        return feedResponse;
+    }
+
+    @Override
+    public List<ReviewRequest> findFeed(String id) {
+        ReviewRequest reviewRequest = new ReviewRequest();
+        return reviewRequest.Review_To_DTO(reviewRepository.findAllByUserReview(id));
+    }
+
+}


### PR DESCRIPTION
FEAT - DB review 테이블에 userUID,kakaoUID 추가 

기존의 ERD에 있는  userUID,kakaoUID 를 실수로 DB에 안넣어서 수정했음
URL:    "/get/review/{id}"
```
  private String  feedUID;

    private String nickname;

    private  String content;

    private String feedImage;

    private  Integer likeCount;

    private  Integer starCount;

    private  String placeArea;

    private Boolean isUserLiked;

    private LocalDateTime createdAt;
```
자신의  userUID 나 kakaoUID를 넣으면  위와 같은 DTO 형태로 보낼것임 
이것도 임시 테스트용이니 나중에 수정하겠음 
