### PR TITLE
FEAT-지역별로 리뷰를 분류하는 기능 구현

### DIFF
--- a/src/main/java/com/LeaveIt/server/controller/ReviewController.java
+++ b/src/main/java/com/LeaveIt/server/controller/ReviewController.java
@@ -46,6 +46,12 @@ public class ReviewController {
         return  reviewService.findReviewAll();
     }
 
+    @GetMapping("/get/review/region/{region}")
+    public List<ReviewRequest> getReviewRegion(@PathVariable String region){
+
+        return  reviewService.findReviewRegionAll(region);
+    }
+
     @PostMapping("/save/like/{feedUID}")
     public void  saveReviewLike(@PathVariable String feedUID, @RequestBody LikeReview likeReview){
 

--- a/src/main/java/com/LeaveIt/server/controller/model/request/ReviewRequest.java
+++ b/src/main/java/com/LeaveIt/server/controller/model/request/ReviewRequest.java
@@ -32,6 +32,8 @@ public class ReviewRequest {
 
     private  String placeArea;
 
+    private  String region;
+
     private Boolean isUserLiked;
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/LeaveIt/server/repository/ReviewRepository.java
+++ b/src/main/java/com/LeaveIt/server/repository/ReviewRepository.java
@@ -42,4 +42,9 @@ public interface ReviewRepository  extends JpaRepository<Review , String> {
     @Query("UPDATE Review r SET r.likeCount = r.likeCount -1 WHERE r.feedUID = :feedUID")
     void  minusCountLike(@Param("feedUID") String  feedUID);
 
+
+    @Query("select  r from Review r where  r.region= :region")
+    List<Review>  findAllByRegionReview(@Param("region") String region);
+
+
 }

--- a/src/main/java/com/LeaveIt/server/repository/entity/Review.java
+++ b/src/main/java/com/LeaveIt/server/repository/entity/Review.java
@@ -34,6 +34,10 @@ public class Review {
 
     private  String content;
 
+
+    private  String region;
+
+
     @Column(name = "feedimage")
     private String feedImage;
 

--- a/src/main/java/com/LeaveIt/server/service/ReviewService.java
+++ b/src/main/java/com/LeaveIt/server/service/ReviewService.java
@@ -15,6 +15,7 @@ public interface ReviewService {
 
     List<ReviewRequest> findReviewAll();
 
+    List<ReviewRequest> findReviewRegionAll(String region);
     void saveReviewLike(String feedUID , LikeReview likeReview);
 
     void cancelReviewLike(String feedUID, LikeReview likeReview);

--- a/src/main/java/com/LeaveIt/server/service/ReviewServiceImpl.java
+++ b/src/main/java/com/LeaveIt/server/service/ReviewServiceImpl.java
@@ -48,6 +48,13 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
+    public List<ReviewRequest> findReviewRegionAll(String region) {
+
+        ReviewRequest reviewRequest=new ReviewRequest();
+        return reviewRequest.Review_To_DTO(reviewRepository.findAllByRegionReview(region));
+    }
+
+    @Override
     @Transactional
     public void saveReviewLike(String feedUID, LikeReview likeReview) {
         checkedLike(feedUID, likeReview);


### PR DESCRIPTION
```
public class ReviewRequest {
    private String  feedUID;

    private String nickname;

    private  String content;

    private String feedImage;

    private  Integer likeCount;

    private  Integer starCount;

    private  String placeArea;

    private  String region;

    private Boolean isUserLiked;

    private LocalDateTime createdAt;

```
요청한대로 ReviewDTO 에   region추가
URL: @GetMapping("/get/review/region/{region}")
클라이언트에서 원하는 region를 입력하면  그 지역에 대한 리뷰를 다 보내는 URL임 
그 지역 리뷰가 없다면 에러처리는 클라이언트와 협의가필요함