### PR TITLE
39 feat  검색 로그 저장 기능 구현

### DIFF
--- a/api/src/main/java/com/example/api/bean/LoginConfig.java
+++ b/api/src/main/java/com/example/api/bean/LoginConfig.java
@@ -1,9 +1,6 @@
 package com.example.api.bean;
 
 import com.example.common.config.JwtTokenProvider;
-import com.example.domain.document.dao.SearchDAO;
-import com.example.domain.searchservice.SearchService;
-import com.example.domain.searchservice.SearchServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/api/src/main/java/com/example/api/searchcontroller/SearchController.java
+++ b/api/src/main/java/com/example/api/searchcontroller/SearchController.java
@@ -3,6 +3,7 @@ package com.example.api.searchcontroller;
 
 import com.example.common.model.request.FoodRequest;
 import com.example.common.model.request.PlaceRequest;
+import com.example.common.model.response.LogResponse;
 import com.example.domain.searchservice.SearchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -48,9 +49,9 @@ public class SearchController {
     }
 
 
-    @PostMapping("/tour/area/log/{text}")
-    public  void saveLog(String  text){
-         searchService.saveLog(text);
+    @PostMapping("/tour/area/log")
+    public  void saveLog(@RequestBody LogResponse response){
+         searchService.saveLog(response);
     }
 
     //    @GetMapping("/food/{areaCode}")

--- a/api/src/main/java/com/example/api/searchcontroller/SearchController.java
+++ b/api/src/main/java/com/example/api/searchcontroller/SearchController.java
@@ -5,10 +5,7 @@ import com.example.common.model.request.FoodRequest;
 import com.example.common.model.request.PlaceRequest;
 import com.example.domain.searchservice.SearchService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,22 +28,40 @@ public class SearchController {
 
         return  searchService.getSearchAreaPlaceList(place,num);
     }
-
-    @GetMapping("/tour/area/type/{cat}")
+    @GetMapping("/tour/area/cat/{cat}")
     public List<PlaceRequest> getTypePlace(@PathVariable String cat, int num)  {
-
         return  searchService.getTypePlaceList(cat,num);
     }
 
-//    @GetMapping("/food/{areaCode}")
-//    public List<FoodRequest> getFoodAreaList(@RequestParam int page, @PathVariable String areaCode ) throws IOException {
-//
-//        return  searchService.getAreaFoodList(page,areaCode);
-//    }
-
-    @GetMapping("/food/area/{areaCode}")
-    public List<FoodRequest> getFoodAreaList(@RequestParam int page, @PathVariable String areaCode ) throws IOException {
-
-        return  searchService.getAreaFoodList(page,areaCode);
+    @GetMapping("/tour/area/type/{cat}")
+    public List<PlaceRequest> getTypeAndAreaPlace(@PathVariable String cat,
+                                           @RequestParam(required = false) String areaCode,
+                                           int num)  {
+        return  searchService.findTypeAndAreaPlace(cat,areaCode,num);
     }
+
+
+    @GetMapping("/tour/area/search/input/{text}")
+    public List<PlaceRequest> getSearchPlace(@PathVariable String text,@RequestParam int num){
+
+        return  searchService.getSearchPlace(num,text);
+    }
+
+
+    @PostMapping("/tour/area/log/{text}")
+    public  void saveLog(String  text){
+         searchService.saveLog(text);
+    }
+
+    //    @GetMapping("/food/{areaCode}")
+    //    public List<FoodRequest> getFoodAreaList(@RequestParam int page, @PathVariable String areaCode ) throws IOException {
+    //
+    //        return  searchService.getAreaFoodList(page,areaCode);
+    //    }
+
+    //    @GetMapping("/food/area/{areaCode}")
+    //    public List<FoodRequest> getFoodAreaList(@RequestParam int page, @PathVariable String areaCode ) throws IOException {
+    //
+    //        return  searchService.getAreaFoodList(page,areaCode);
+    //    }
 }

--- a/common/src/main/java/com/example/common/model/request/PlaceRequest.java
+++ b/common/src/main/java/com/example/common/model/request/PlaceRequest.java
@@ -23,11 +23,13 @@ public class PlaceRequest {
 
     private  String contentId;
 
+    private  String  contentTypeId;
+
     private  String firstImage;
 
-    private  String mapX;
+    private  Double longtitude;
 
-    private  String  mapY;
+    private Double  langitutde;
 
     private  String tel;
 }

--- a/common/src/main/java/com/example/common/model/response/LogResponse.java
+++ b/common/src/main/java/com/example/common/model/response/LogResponse.java
@@ -1,0 +1,17 @@
+package com.example.common.model.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LogResponse {
+
+
+    private  String title;
+
+}

--- a/common/src/main/java/com/example/common/model/response/ReviewResponse.java
+++ b/common/src/main/java/com/example/common/model/response/ReviewResponse.java
@@ -42,5 +42,4 @@ public class ReviewResponse {
     private LocalDateTime updatedAt;
 
 
-
 }

--- a/domain/src/main/java/com/example/domain/document/Place.java
+++ b/domain/src/main/java/com/example/domain/document/Place.java
@@ -14,7 +14,7 @@ public class Place {
     @Id
     private  String id;
 
-    private String areacode;
+    private String areaCode;
 
     private String  cat;
 
@@ -22,16 +22,17 @@ public class Place {
 
     private  String addr1;
 
+    private  String  contenttypeid;
 
     private  String contentid;
 
     private  String firstimage;
 
 
-    private  String mapx;
+    private  Double longtitude;
 
 
-    private  String  mapy;
+    private  Double langitutde;
 
     private  String tel;
 

--- a/domain/src/main/java/com/example/domain/document/PlaceLog.java
+++ b/domain/src/main/java/com/example/domain/document/PlaceLog.java
@@ -1,0 +1,32 @@
+package com.example.domain.document;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+import java.time.LocalDateTime;
+
+@Data
+@Document(indexName = "placelog")
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlaceLog {
+
+    @Id
+    private  String id;
+
+    private  String title;
+
+
+    private LocalDateTime createdAt;
+
+    public PlaceLog(String title) {
+        this.title = title;
+    }
+
+}

--- a/domain/src/main/java/com/example/domain/document/dao/CategoryDAO.java
+++ b/domain/src/main/java/com/example/domain/document/dao/CategoryDAO.java
@@ -1,0 +1,24 @@
+package com.example.domain.document.dao;
+
+
+import com.example.domain.document.Food;
+import com.example.domain.document.Place;
+
+import java.io.IOException;
+import java.util.List;
+
+
+public interface CategoryDAO {
+
+
+    List<Place> findAreaPlace(String  area, int num);
+
+    List<Place> findTypePlace(String cat,int num);
+    List<Place> findTypeAndAreaPlace(String cat,String areaCode,int num);
+    List<Place> searchAreaPlace(String area,int num);
+
+    void saveAreaPlace(String cat,int num);
+
+
+    List<Food> findAreaFood(int num, String areaCode) throws  IOException;
+}

--- a/domain/src/main/java/com/example/domain/document/dao/SearchDAO.java
+++ b/domain/src/main/java/com/example/domain/document/dao/SearchDAO.java
@@ -1,16 +1,17 @@
 package com.example.domain.document.dao;
 
 import com.example.domain.document.Place;
+import com.example.domain.document.PlaceLog;
 
 import java.util.List;
-
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 
 public interface SearchDAO {
 
     List<Place> searchPlace(int num, String text);
 
-    void saveSearchLog(String  text);
+    void saveSearchLog(List<PlaceLog> batchLogs);
 
 
 }

--- a/domain/src/main/java/com/example/domain/document/dao/SearchDAO.java
+++ b/domain/src/main/java/com/example/domain/document/dao/SearchDAO.java
@@ -1,23 +1,16 @@
 package com.example.domain.document.dao;
 
-
-import com.example.domain.document.Food;
 import com.example.domain.document.Place;
 
-import java.io.IOException;
 import java.util.List;
+
 
 
 public interface SearchDAO {
 
+    List<Place> searchPlace(int num, String text);
 
-    List<Place> findAreaPlace(String  area, int num);
-
-    List<Place> findTypePlace(String area,int num);
-    List<Place> searchAreaPlace(String area,int num);
-
-    void saveAreaPlace(String area,int num);
+    void saveSearchLog(String  text);
 
 
-    List<Food> findAreaFood(int num, String areaCode) throws  IOException;
 }

--- a/domain/src/main/java/com/example/domain/mapper/PlaceMapper.java
+++ b/domain/src/main/java/com/example/domain/mapper/PlaceMapper.java
@@ -20,13 +20,14 @@ public class PlaceMapper {
                 .map(t -> PlaceRequest.builder()
                         .contentId(t.getContentid())
                         .cat(t.getCat())
-                        .areaCode(t.getAreacode())
+                        .areaCode(t.getAreaCode())
                         .addr1(t.getAddr1())
+                        .contentTypeId(t.getContenttypeid())
                         .title(t.getTitle())
                         .tel(t.getTel())
                         .firstImage(t.getFirstimage())
-                        .mapX(t.getMapx())
-                        .mapY(t.getMapy())
+                        .longtitude(t.getLongtitude())
+                        .langitutde(t.getLangitutde())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/domain/src/main/java/com/example/domain/searchservice/SearchService.java
+++ b/domain/src/main/java/com/example/domain/searchservice/SearchService.java
@@ -2,6 +2,7 @@ package com.example.domain.searchservice;
 
 import com.example.common.model.request.FoodRequest;
 import com.example.common.model.request.PlaceRequest;
+import com.example.common.model.response.LogResponse;
 import com.example.domain.document.Place;
 
 import java.io.IOException;
@@ -19,7 +20,7 @@ public interface SearchService {
 
     List<PlaceRequest> getSearchPlace(int num, String text);
 
-    void saveLog(String text);
+    void saveLog(LogResponse logResponse);
 
     List<FoodRequest> getAreaFoodList(int num, String areaCode) throws IOException;
 }

--- a/domain/src/main/java/com/example/domain/searchservice/SearchService.java
+++ b/domain/src/main/java/com/example/domain/searchservice/SearchService.java
@@ -13,7 +13,13 @@ public interface SearchService {
 
     List<PlaceRequest> getSearchAreaPlaceList(String place,int num);
 
+    List<PlaceRequest> findTypeAndAreaPlace(String cat,String areaCode,int num);
+
     List<PlaceRequest> getTypePlaceList(String cat,int num);
+
+    List<PlaceRequest> getSearchPlace(int num, String text);
+
+    void saveLog(String text);
 
     List<FoodRequest> getAreaFoodList(int num, String areaCode) throws IOException;
 }

--- a/domain/src/main/java/com/example/domain/searchservice/SearchServiceImpl.java
+++ b/domain/src/main/java/com/example/domain/searchservice/SearchServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.domain.searchservice;
 
 import com.example.common.model.request.FoodRequest;
 import com.example.common.model.request.PlaceRequest;
+import com.example.domain.document.dao.CategoryDAO;
 import com.example.domain.document.dao.SearchDAO;
 import com.example.domain.mapper.FoodMapper;
 import com.example.domain.mapper.PlaceMapper;
@@ -18,29 +19,49 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SearchServiceImpl  implements  SearchService{
 
+    private  final CategoryDAO categoryDAO;
+
     private  final SearchDAO searchDAO;
 
     private  final FoodMapper foodMapper;
     private  final PlaceMapper touristMapper;
     @Override
     public List<PlaceRequest> getAreaPlaceList(String area,int num)  {
-        return touristMapper.Tourist_To_DTO(searchDAO.findAreaPlace(area,num));
+        return touristMapper.Tourist_To_DTO(categoryDAO.findAreaPlace(area,num));
     }
 
 
     @Override
     public List<PlaceRequest> getSearchAreaPlaceList(String place,int num)  {
-        return touristMapper.Tourist_To_DTO(searchDAO.searchAreaPlace(place,num));
+        return touristMapper.Tourist_To_DTO(categoryDAO.searchAreaPlace(place,num));
     }
 
     @Override
-    public List<PlaceRequest> getTypePlaceList(String cat, int num) {
+    public List<PlaceRequest> findTypeAndAreaPlace(String cat, String areaCode, int num) {
 
-        return touristMapper.Tourist_To_DTO(searchDAO.findTypePlace(cat,num));
+        return  touristMapper.Tourist_To_DTO(categoryDAO.findTypeAndAreaPlace(cat,areaCode,num));
     }
 
+
+    @Override
+    public List<PlaceRequest> getTypePlaceList(String cat,int num) {
+
+        return touristMapper.Tourist_To_DTO(categoryDAO.findTypePlace(cat,num));
+    }
+
+    @Override
+    public List<PlaceRequest> getSearchPlace(int num, String text) {
+        return  touristMapper.Tourist_To_DTO(searchDAO.searchPlace(num,text));
+    }
+
+    @Override
+    public void saveLog(String text) {
+
+        searchDAO.saveSearchLog(text);
+    }
+    
     @Override
     public List<FoodRequest> getAreaFoodList(int num, String  areaCode) throws IOException {
-        return foodMapper.Food_To_DTO(searchDAO.findAreaFood(num,areaCode));
+        return foodMapper.Food_To_DTO(categoryDAO.findAreaFood(num,areaCode));
     }
 }

--- a/domain/src/main/java/com/example/domain/searchservice/SearchServiceImpl.java
+++ b/domain/src/main/java/com/example/domain/searchservice/SearchServiceImpl.java
@@ -2,16 +2,24 @@ package com.example.domain.searchservice;
 
 import com.example.common.model.request.FoodRequest;
 import com.example.common.model.request.PlaceRequest;
+import com.example.common.model.response.LogResponse;
+import com.example.domain.document.Place;
+import com.example.domain.document.PlaceLog;
 import com.example.domain.document.dao.CategoryDAO;
 import com.example.domain.document.dao.SearchDAO;
 import com.example.domain.mapper.FoodMapper;
 import com.example.domain.mapper.PlaceMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 
 @Slf4j
@@ -22,9 +30,14 @@ public class SearchServiceImpl  implements  SearchService{
     private  final CategoryDAO categoryDAO;
 
     private  final SearchDAO searchDAO;
+    private final ConcurrentLinkedQueue<PlaceLog> logQueue = new ConcurrentLinkedQueue<>();
+
+    private static final int BATCH_SIZE = 20;  //
 
     private  final FoodMapper foodMapper;
     private  final PlaceMapper touristMapper;
+
+
     @Override
     public List<PlaceRequest> getAreaPlaceList(String area,int num)  {
         return touristMapper.Tourist_To_DTO(categoryDAO.findAreaPlace(area,num));
@@ -53,15 +66,41 @@ public class SearchServiceImpl  implements  SearchService{
     public List<PlaceRequest> getSearchPlace(int num, String text) {
         return  touristMapper.Tourist_To_DTO(searchDAO.searchPlace(num,text));
     }
-
-    @Override
-    public void saveLog(String text) {
-
-        searchDAO.saveSearchLog(text);
-    }
-    
     @Override
     public List<FoodRequest> getAreaFoodList(int num, String  areaCode) throws IOException {
         return foodMapper.Food_To_DTO(categoryDAO.findAreaFood(num,areaCode));
     }
+    @Override
+    @Async("taskExecutor")
+    public void saveLog(LogResponse logResponse) {
+        PlaceLog title = new PlaceLog(logResponse.getTitle());
+        logQueue.add(title);
+
+        // 로그가 20개 이상이면 즉시 저장 실행
+        log.info( String.valueOf(logQueue.size()));
+        if (logQueue.size() >= BATCH_SIZE) {
+            saveLogsToElasticsearch();
+        }
+
+    }
+    private void saveLogsToElasticsearch() {
+        if (logQueue.isEmpty()) return;
+
+        List<PlaceLog> batchLogs = new ArrayList<>();
+        while (!logQueue.isEmpty() && batchLogs.size() < BATCH_SIZE) {
+            batchLogs.add(logQueue.poll());
+        }
+
+        if (!batchLogs.isEmpty()) {
+
+            searchDAO.saveSearchLog(batchLogs);
+        }
+    }
+    @Scheduled(fixedRate = 5000)
+    @Async("taskExecutor")
+    public void flushLogs() {
+        saveLogsToElasticsearch();
+
+    }
+
 }

--- a/infra/src/main/java/com/example/infra/elasticsearch/CategoryDAOImpl.java
+++ b/infra/src/main/java/com/example/infra/elasticsearch/CategoryDAOImpl.java
@@ -1,0 +1,131 @@
+package com.example.infra.elasticsearch;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.IndexResponse;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import com.example.common.exception.db.EsIoException;
+import com.example.domain.document.Food;
+import com.example.domain.document.Place;
+import com.example.domain.document.dao.CategoryDAO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.example.common.exception.db.DBErrorCode.ES_NOT_FOUND;
+
+
+@Repository
+@Slf4j
+@RequiredArgsConstructor
+public class CategoryDAOImpl implements CategoryDAO {
+
+    private final ElasticsearchClient client;
+    @Override
+    public List<Place> findAreaPlace(String area,int num)  {
+        try {
+            SearchResponse<Place> response = client.search(s -> s
+                    .index("place")
+                    .from((num - 1) * 10)
+                    .size(10)
+                    .query(q -> q.term(t -> t.value(area)
+                            .field("areacode"))), Place.class);
+            return  response.hits().hits().stream()
+                    .map(hit->hit.source())
+                    .collect(Collectors.toList());
+        }catch (IOException e){
+            log.error("데이터 값이 없습니다");
+            throw new EsIoException(ES_NOT_FOUND);
+        }}
+
+    @Override
+    public List<Place> findTypePlace(String cat,int num)  {
+        try {
+            SearchResponse<Place> response = client.search(s -> s
+                    .index("place")
+                    .from((num - 1) * 10)
+                    .size(10)
+                    .query(q -> q.term(t -> t.value(cat)
+                            .field("cat"))), Place.class);
+            return  response.hits().hits().stream()
+                    .map(hit->hit.source())
+                    .collect(Collectors.toList());
+        }catch (IOException e){
+            log.error("데이터 값이 없습니다");
+            throw new EsIoException(ES_NOT_FOUND);
+        }
+    }
+
+    @Override
+    public List<Place> findTypeAndAreaPlace(String cat,String areaCode,int num)  {
+        try {
+            SearchResponse<Place> response = client.search(s -> s
+                            .index("place")
+                            .from((num - 1) * 10)
+                            .size(10)
+                            .query(q -> q.bool(b -> b
+                                    .filter(a -> a.term(t -> t.field("cat").value(cat)))
+                                    .filter(f -> f.term(t -> t.field("areaCode").value(areaCode)))))
+                    ,Place.class);
+            return  response.hits().hits().stream()
+                    .map(hit->hit.source())
+                    .collect(Collectors.toList());
+        }catch (IOException e){
+            log.error("데이터 값이 없습니다");
+            throw new EsIoException(ES_NOT_FOUND);
+        }
+    }
+
+
+    @Override
+    public List<Place> searchAreaPlace(String place,int num)  {
+        try {
+            SearchResponse<Place> response = client.search(s -> s
+                    .index("place")
+                    .from((num - 1) * 10)
+                    .size(10)
+                    .query(q -> q.match(t ->t.field("addr1")
+                            .query(place))), Place.class);
+            return  response.hits().hits().stream()
+                    .map(hit->hit.source())
+                    .collect(Collectors.toList());
+        }catch (IOException e){
+            log.error("데이터 값이 없습니다");
+            throw new EsIoException(ES_NOT_FOUND);
+        }}
+
+    @Override
+    public void saveAreaPlace(String area,int num) {
+        try {
+            IndexResponse response = client.index(s -> s
+                    .index("places")
+                    .id(UUID.randomUUID().toString())
+                    .document(area));
+        } catch (IOException e) {
+            log.error("데이터 값이 없습니다");
+            throw new EsIoException(ES_NOT_FOUND);
+        }
+    }
+
+    @Override
+    public List<Food> findAreaFood(int num, String areaCode) throws IOException {
+        SearchResponse<Food> response=client.search(s->s
+                        .index("food")
+                        .from( (num - 1) * 10)
+                        .size(10)
+                        .query(q->q.term(t->t.value(areaCode)
+                                .field("areaCode")))
+                , Food.class);
+        return  response.hits().hits().stream()
+                .map(hit->hit.source())
+                .collect(Collectors.toList());
+    }
+}
+
+
+

--- a/infra/src/main/java/com/example/infra/elasticsearch/SearchDAOImpl.java
+++ b/infra/src/main/java/com/example/infra/elasticsearch/SearchDAOImpl.java
@@ -1,113 +1,80 @@
 package com.example.infra.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreMode;
 import co.elastic.clients.elasticsearch.core.IndexResponse;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
-import com.example.common.exception.db.DBIoException;
 import com.example.common.exception.db.EsIoException;
-import com.example.domain.document.Food;
 import com.example.domain.document.Place;
 import com.example.domain.document.dao.SearchDAO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
-
 import java.io.IOException;
 import java.util.List;
-import java.util.Random;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.example.common.exception.db.DBErrorCode.ES_NOT_FOUND;
 
 
-@Repository
 @Slf4j
+@Repository
 @RequiredArgsConstructor
-public class SearchDAOImpl implements SearchDAO {
+public class SearchDAOImpl implements  SearchDAO {
 
     private final ElasticsearchClient client;
     @Override
-    public List<Place> findAreaPlace(String area,int num)  {
+    public List<Place> searchPlace(int num, String text) {
         try {
             SearchResponse<Place> response = client.search(s -> s
                     .index("place")
                     .from((num - 1) * 10)
                     .size(10)
-                    .query(q -> q.term(t -> t.value(area)
-                            .field("areacode"))), Place.class);
+                    .query(q -> q.functionScore(fs -> fs
+                            .query(q2 -> q2.bool(b -> b
+                                    .should(q3 -> q3.match(m -> m
+                                            .field("title")
+                                            .query(text)
+                                            .fuzziness("AUTO")
+                                    ))
+                                    .should(q4 -> q4.matchPhrase(m -> m
+                                            .field("title")
+                                            .query(text)
+                                    ))
+
+                            ))
+                            .functions(fn -> fn
+                                    .filter(f -> f.matchPhrase(mp -> mp
+                                            .field("title")
+                                            .query(text)
+                                    ))
+                                    .weight(5.0)
+                            )
+                            .scoreMode(FunctionScoreMode.Multiply)
+                    )), Place.class);
+
+            log.info(response.toString());
             return  response.hits().hits().stream()
                     .map(hit->hit.source())
                     .collect(Collectors.toList());
         }catch (IOException e){
-            log.error("데이터 값이 없습니다");
-            throw new EsIoException(ES_NOT_FOUND);
-        }}
-
-    @Override
-    public List<Place> findTypePlace(String cat,int num)  {
-        try {
-            SearchResponse<Place> response = client.search(s -> s
-                    .index("place")
-                    .from((num - 1) * 10)
-                    .size(10)
-                    .query(q -> q.term(t -> t.value(cat)
-                            .field("cat"))), Place.class);
-            return  response.hits().hits().stream()
-                    .map(hit->hit.source())
-                    .collect(Collectors.toList());
-        }catch (IOException e){
-            log.error("데이터 값이 없습니다");
-            throw new EsIoException(ES_NOT_FOUND);
-        }
-    }
-
-
-    @Override
-    public List<Place> searchAreaPlace(String place,int num)  {
-        try {
-            SearchResponse<Place> response = client.search(s -> s
-                    .index("place")
-                    .from((num - 1) * 10)
-                    .size(10)
-                    .query(q -> q.match(t ->t.field("addr1")
-                            .query(place))), Place.class);
-            return  response.hits().hits().stream()
-                    .map(hit->hit.source())
-                    .collect(Collectors.toList());
-        }catch (IOException e){
-            log.error("데이터 값이 없습니다");
-            throw new EsIoException(ES_NOT_FOUND);
-        }}
-
-    @Override
-    public void saveAreaPlace(String area,int num) {
-        try {
-            IndexResponse response = client.index(s -> s
-                    .index("places")
-                    .id(UUID.randomUUID().toString())
-                    .document(area));
-        } catch (IOException e) {
-            log.error("데이터 값이 없습니다");
+            log.error("데이터 값이 존재하지않습니다");
             throw new EsIoException(ES_NOT_FOUND);
         }
     }
 
     @Override
-    public List<Food> findAreaFood(int num, String areaCode) throws IOException {
-        SearchResponse<Food> response=client.search(s->s
-                        .index("food")
-                        .from( (num - 1) * 10)
-                        .size(10)
-                        .query(q->q.term(t->t.value(areaCode)
-                                .field("areaCode")))
-                , Food.class);
-        return  response.hits().hits().stream()
-                .map(hit->hit.source())
-                .collect(Collectors.toList());
+    public void saveSearchLog(String text) {
+        try {
+            IndexResponse response=client.index(i->i
+                    .index("placelog")
+                    .document(text));
+            }catch (IOException e){
+                log.error("데이터 값이 존재하지않습니다");
+                throw new EsIoException(ES_NOT_FOUND);
+            }
     }
+
+
 }
-
-
-

--- a/infra/src/main/java/com/example/infra/elasticsearch/SearchDAOImpl.java
+++ b/infra/src/main/java/com/example/infra/elasticsearch/SearchDAOImpl.java
@@ -2,10 +2,13 @@ package com.example.infra.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreMode;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.IndexResponse;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import com.example.common.exception.db.EsIoException;
 import com.example.domain.document.Place;
+import com.example.domain.document.PlaceLog;
 import com.example.domain.document.dao.SearchDAO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +16,7 @@ import org.springframework.stereotype.Repository;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 import static com.example.common.exception.db.DBErrorCode.ES_NOT_FOUND;
@@ -24,6 +28,7 @@ import static com.example.common.exception.db.DBErrorCode.ES_NOT_FOUND;
 public class SearchDAOImpl implements  SearchDAO {
 
     private final ElasticsearchClient client;
+
     @Override
     public List<Place> searchPlace(int num, String text) {
         try {
@@ -55,26 +60,37 @@ public class SearchDAOImpl implements  SearchDAO {
                     )), Place.class);
 
             log.info(response.toString());
-            return  response.hits().hits().stream()
-                    .map(hit->hit.source())
+            return response.hits().hits().stream()
+                    .map(hit -> hit.source())
                     .collect(Collectors.toList());
-        }catch (IOException e){
+        } catch (IOException e) {
             log.error("데이터 값이 존재하지않습니다");
             throw new EsIoException(ES_NOT_FOUND);
         }
     }
 
     @Override
-    public void saveSearchLog(String text) {
+    public void saveSearchLog(List<PlaceLog> batchLogs) {
+        log.info(batchLogs.toString());
         try {
-            IndexResponse response=client.index(i->i
-                    .index("placelog")
-                    .document(text));
-            }catch (IOException e){
+            BulkRequest.Builder bulkRequest = new BulkRequest.Builder();
+
+            for (PlaceLog log : batchLogs) {
+                bulkRequest.operations(op -> op
+                        .index(idx -> idx
+                                .index("placelog")
+                                .document(log)
+                        ));
+
+            }
+            BulkResponse response = client.bulk(bulkRequest.build());
+            if (response.errors()) {
+                System.err.println("Bulk insert 실패: " + response.toString());
+            }
+            } catch (IOException e) {
                 log.error("데이터 값이 존재하지않습니다");
                 throw new EsIoException(ES_NOT_FOUND);
             }
+        }
     }
 
-
-}


### PR DESCRIPTION
```
   @PostMapping("/tour/area/log")
    public  void saveLog(@RequestBody LogResponse response){
         searchService.saveLog(response);
    }
    
```
URL
검색 로그를 저장하는 URL 
JSON안에  ex) "title": "경복궁"  이런식으로 값을 넣는식으로 하면됨
```

 @Async("taskExecutor")
    public void saveLog(LogResponse logResponse) {
        PlaceLog title = new PlaceLog(logResponse.getTitle());
        logQueue.add(title);

        // 로그가 20개 이상이면 즉시 저장 실행
        log.info( String.valueOf(logQueue.size()));
        if (logQueue.size() >= BATCH_SIZE) {
            saveLogsToElasticsearch();
        }

    }
    private void saveLogsToElasticsearch() {
        if (logQueue.isEmpty()) return;

        List<PlaceLog> batchLogs = new ArrayList<>();
        while (!logQueue.isEmpty() && batchLogs.size() < BATCH_SIZE) {
            batchLogs.add(logQueue.poll());
        }

        if (!batchLogs.isEmpty()) {

            searchDAO.saveSearchLog(batchLogs);
        }
    }
    @Scheduled(fixedRate = 5000)
    @Async("taskExecutor")
    public void flushLogs() {
        saveLogsToElasticsearch();

    }
```
검색 로그를 비동기 형식으로 받아와 Bulk 쿼리를 날리는 형식임 
Bulk쿼리란 한번에 하나씩 데이터를 DB에 넣지않고  개발자가 지정한 쿼리 개수만큼 큐에 저장해 데이터를 넣는형식임
이번 프로젝트에서는 배치 크기를 20개로 지정해 20개를 채우면 한번에 쿼리가 날라감 